### PR TITLE
use gromacs 2020.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM nvidia/cuda:9.0-devel-ubuntu16.04 as builder
 
 # Update according to http://manual.gromacs.org/documentation/
 ARG GROMACS_VERSION=2020.1
-ARG GROMACS_MD5=c1b5c0f904d4eac7e3515bc01ce3781
+ARG GROMACS_MD5=1c1b5c0f904d4eac7e3515bc01ce3781
 
 ARG FFTW_VERSION=3.3.8
 ARG FFTW_MD5=8aac833c943d8e90d51b697b27d4384d

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@
 FROM nvidia/cuda:9.0-devel-ubuntu16.04 as builder
 
 # Update according to http://manual.gromacs.org/documentation/
-ARG GROMACS_VERSION=2019.4
-ARG GROMACS_MD5=b424b9099f8bb00e1cd716a1295d797e
+ARG GROMACS_VERSION=2020.1
+ARG GROMACS_MD5=c1b5c0f904d4eac7e3515bc01ce3781
 
 ARG FFTW_VERSION=3.3.8
 ARG FFTW_MD5=8aac833c943d8e90d51b697b27d4384d


### PR DESCRIPTION
Hi,

I'm wondering if v2020.1 could also be available on dockerhub.
I also though about updating the docker base to  nvidia/cuda:10.2-devel-ubuntu18.04`.
Would you accept it?


Best